### PR TITLE
Upgrade pandas & xarray versions; fixed pandas date_range issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ base_requires = [
     'apache_beam>=2.31.0',
     'jax[cpu]',
     'numpy',
-    'pandas<1.4',
+    'pandas==2.0.3',
     'scipy',
     'scikit-learn',
-    'xarray==2022.3.0',
+    'xarray==2023.7.0',
     'xarray-beam',
     'zarr',
 ]

--- a/weatherbench2/schema.py
+++ b/weatherbench2/schema.py
@@ -75,7 +75,7 @@ def mock_truth_data(
   num_longitudes = round(360 / spatial_resolution_in_degrees)
   freq = pd.Timedelta(time_resolution)
   coords = {
-      'time': pd.date_range(time_start, time_stop, freq=freq, closed='left'),
+      'time': pd.date_range(time_start, time_stop, freq=freq, inclusive='left'),
       'latitude': np.linspace(-90, 90, num_latitudes),
       'longitude': np.linspace(0, 360, num_longitudes, endpoint=False),
       'level': np.array(levels),


### PR DESCRIPTION
In pandas 1.4.0, `closed` was changed to `inclusive`. Now that this kwargs is updated, we can upgrade pandas to the latest version (2.0+) -- and also xarray.

Fixes #23 (I hope).