### PR TITLE
Removing isort lint check.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Install Weatherbench 2
       run: |
         pip install -e .[tests]
-    - name: Lint with pyink and isort
+    - name: Lint with pyink
       run: |
         pyink --check .
-        isort --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,3 @@ line-length = 80
 preview = true
 pyink-indentation = 2
 pyink-use-majority-quotes = true
-
-[tool.isort]
-profile = "google"
-use_parentheses = true
-known_third_party= ['absl', 'weatherbench2']
-multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ tests_requires = [
     'absl-py',
     'pytest',
     'pyink',
-    'isort',
 ]
 
 gcp_requires = [


### PR DESCRIPTION
Almost working is way worse than not working at all. Specifically, we get conflicts between internal and external sorting rules. Better to just get rid of this.

Unblocks #13.