### PR TITLE
Renaming config objects to be more succinct. 

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -48,7 +48,7 @@
     config.Selection
     config.Paths
     config.DataConfig
-    config.EvalConfig
+    config.Eval
     config.VizConfig
     config.PanelConfig
 ```

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -50,7 +50,7 @@
     config.Data
     config.Eval
     config.Viz
-    config.PanelConfig
+    config.Panel
 ```
 
 ## Regions

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -49,7 +49,7 @@
     config.Paths
     config.Data
     config.Eval
-    config.VizConfig
+    config.Viz
     config.PanelConfig
 ```
 

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -47,7 +47,7 @@
 
     config.Selection
     config.Paths
-    config.DataConfig
+    config.Data
     config.Eval
     config.VizConfig
     config.PanelConfig

--- a/docs/source/command-line-scripts.md
+++ b/docs/source/command-line-scripts.md
@@ -80,7 +80,7 @@ deterministic_metrics = {
 }
 
 eval_configs = {
-  'deterministic': Eval(
+  'deterministic': config.Eval(
       metrics=deterministic_metrics,
       against_analysis=False,
       regions=regions,
@@ -88,14 +88,14 @@ eval_configs = {
       evaluate_persistence=EVALUATE_PERSISTENCE.value,
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
   ),
-  'deterministic_spatial': Eval(
+  'deterministic_spatial': config.Eval(
       metrics={'bias': SpatialBias(), 'mse': SpatialMSE()},
       against_analysis=False,
       derived_variables=derived_variables,
       evaluate_persistence=EVALUATE_PERSISTENCE.value,
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
   ),
-  'deterministic_temporal': Eval(
+  'deterministic_temporal': config.Eval(
       metrics=deterministic_metrics,
       against_analysis=False,
       regions=regions,
@@ -104,7 +104,7 @@ eval_configs = {
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
       temporal_mean=False,
   ),
-  'probabilistic': Eval(
+  'probabilistic': config.Eval(
       metrics={
           'crps': CRPS(ensemble_dim=ENSEMBLE_DIM.value),
           'ensemble_mean_rmse': EnsembleMeanRMSE(

--- a/docs/source/command-line-scripts.md
+++ b/docs/source/command-line-scripts.md
@@ -80,7 +80,7 @@ deterministic_metrics = {
 }
 
 eval_configs = {
-  'deterministic': EvalConfig(
+  'deterministic': Eval(
       metrics=deterministic_metrics,
       against_analysis=False,
       regions=regions,
@@ -88,14 +88,14 @@ eval_configs = {
       evaluate_persistence=EVALUATE_PERSISTENCE.value,
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
   ),
-  'deterministic_spatial': EvalConfig(
+  'deterministic_spatial': Eval(
       metrics={'bias': SpatialBias(), 'mse': SpatialMSE()},
       against_analysis=False,
       derived_variables=derived_variables,
       evaluate_persistence=EVALUATE_PERSISTENCE.value,
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
   ),
-  'deterministic_temporal': EvalConfig(
+  'deterministic_temporal': Eval(
       metrics=deterministic_metrics,
       against_analysis=False,
       regions=regions,
@@ -104,7 +104,7 @@ eval_configs = {
       evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
       temporal_mean=False,
   ),
-  'probabilistic': EvalConfig(
+  'probabilistic': Eval(
       metrics={
           'crps': CRPS(ensemble_dim=ENSEMBLE_DIM.value),
           'ensemble_mean_rmse': EnsembleMeanRMSE(

--- a/docs/source/evaluation.ipynb
+++ b/docs/source/evaluation.ipynb
@@ -9810,7 +9810,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from weatherbench2.config import Selection, Paths, Data, Eval"
+    "from weatherbench2 import config"
    ]
   },
   {
@@ -9831,7 +9831,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "paths = Paths(\n",
+    "paths = config.Paths(\n",
     "    forecast=forecast_path,\n",
     "    obs=obs_path,\n",
     "    output_dir='./',   # Directory to save evaluation results\n",
@@ -9854,7 +9854,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "selection = Selection(\n",
+    "selection = config.Selection(\n",
     "    variables=[\n",
     "        'geopotential',\n",
     "        '2m_temperature'\n",
@@ -9880,7 +9880,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_config = Data(selection=selection, paths=paths)"
+    "data_config = config.Data(selection=selection, paths=paths)"
    ]
   },
   {
@@ -9906,7 +9906,7 @@
     "from weatherbench2.metrics import RMSE, ACC\n",
     "\n",
     "eval_configs = {\n",
-    "  'deterministic': Eval(\n",
+    "  'deterministic': config.Eval(\n",
     "      metrics={\n",
     "          'rmse': RMSE(), \n",
     "          'acc': ACC(climatology=climatology) \n",
@@ -9940,7 +9940,7 @@
     "}\n",
     "\n",
     "eval_configs = {\n",
-    "  'deterministic': Eval(\n",
+    "  'deterministic': config.Eval(\n",
     "      metrics={\n",
     "          'rmse': RMSE(), \n",
     "          'acc': ACC(climatology=climatology) \n",

--- a/docs/source/evaluation.ipynb
+++ b/docs/source/evaluation.ipynb
@@ -9810,7 +9810,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from weatherbench2.config import Selection, Paths, DataConfig, Eval"
+    "from weatherbench2.config import Selection, Paths, Data, Eval"
    ]
   },
   {
@@ -9870,7 +9870,7 @@
    "id": "d5286330-d0f4-4da9-8394-f8536790dd9c",
    "metadata": {},
    "source": [
-    "Together they make up the DataConfig:"
+    "Together they make up the Data config:"
    ]
   },
   {
@@ -9880,7 +9880,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_config = DataConfig(selection=selection, paths=paths)"
+    "data_config = Data(selection=selection, paths=paths)"
    ]
   },
   {

--- a/docs/source/evaluation.ipynb
+++ b/docs/source/evaluation.ipynb
@@ -9810,7 +9810,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from weatherbench2.config import Selection, Paths, DataConfig, EvalConfig"
+    "from weatherbench2.config import Selection, Paths, DataConfig, Eval"
    ]
   },
   {
@@ -9891,7 +9891,7 @@
    "source": [
     "#### Evaluation configuration\n",
     "\n",
-    "Next, we can defined which evaluation we want to run. To do so, we can define a dictionary of EvalConfigs, each of which will be evaluated separately and saved to a different file. EvalConfig instances contain the metrics objects, defined in metrics.py. \n",
+    "Next, we can defined which evaluation we want to run. To do so, we can define a dictionary of `config.Eval`s, each of which will be evaluated separately and saved to a different file. Eval instances contain the metrics objects, defined in metrics.py.\n",
     "\n",
     "Note that for ACC, we additionally need to pass the climatology opened earlier."
    ]
@@ -9906,7 +9906,7 @@
     "from weatherbench2.metrics import RMSE, ACC\n",
     "\n",
     "eval_configs = {\n",
-    "  'deterministic': EvalConfig(\n",
+    "  'deterministic': Eval(\n",
     "      metrics={\n",
     "          'rmse': RMSE(), \n",
     "          'acc': ACC(climatology=climatology) \n",
@@ -9940,7 +9940,7 @@
     "}\n",
     "\n",
     "eval_configs = {\n",
-    "  'deterministic': EvalConfig(\n",
+    "  'deterministic': Eval(\n",
     "      metrics={\n",
     "          'rmse': RMSE(), \n",
     "          'acc': ACC(climatology=climatology) \n",

--- a/docs/source/init-vs-valid-time.md
+++ b/docs/source/init-vs-valid-time.md
@@ -1,6 +1,6 @@
 # Init vs Valid Time Conventions
 
-The WeatherBench 2 evaluation code can work with two forecast time conventions: init-time and valid-time. For all official WB2 evaluation, the init-time convention is used. You can switch between the conventions using the `by_init` parameter in the `DataConfig`.
+The WeatherBench 2 evaluation code can work with two forecast time conventions: init-time and valid-time. For all official WB2 evaluation, the init-time convention is used. You can switch between the conventions using the `by_init` parameter in the `config.Data`.
 
 ## Init-time convention
 Here, the `time` dimension of the forecast dataset refers to the initialization time of each forecast. To get the time at which each forecast step is valid, one has to add the `lead_time` (also called `prediction_timedelta`). This is the format used by ECMWF. To avoid confusion, the WB2 code internally renames the `time` dimension to `init_time` and a `valid_time` dimension is created from `init_time` + `lead_time`. 

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -263,7 +263,7 @@ def main(argv: list[str]) -> None:
       if RENAME_VARIABLES.value
       else None
   )
-  data_config = config.DataConfig(
+  data_config = config.Data(
       selection=selection,
       paths=paths,
       by_init=BY_INIT.value,

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -337,7 +337,7 @@ def main(argv: list[str]) -> None:
   ]
 
   eval_configs = {
-      'deterministic': config.EvalConfig(
+      'deterministic': config.Eval(
           metrics=deterministic_metrics,
           against_analysis=False,
           regions=regions,
@@ -345,7 +345,7 @@ def main(argv: list[str]) -> None:
           evaluate_persistence=EVALUATE_PERSISTENCE.value,
           evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
       ),
-      'deterministic_spatial': config.EvalConfig(
+      'deterministic_spatial': config.Eval(
           metrics=spatial_metrics,
           against_analysis=False,
           derived_variables=derived_variables,
@@ -353,7 +353,7 @@ def main(argv: list[str]) -> None:
           evaluate_climatology=EVALUATE_CLIMATOLOGY.value,
           output_format='zarr',
       ),
-      'deterministic_temporal': config.EvalConfig(
+      'deterministic_temporal': config.Eval(
           metrics=deterministic_metrics,
           against_analysis=False,
           regions=regions,
@@ -364,13 +364,13 @@ def main(argv: list[str]) -> None:
       ),
       # Against analysis is deprecated for by_init, since the time intervals are
       # not compatible. Still functional for by_valid
-      'deterministic_vs_analysis': config.EvalConfig(
+      'deterministic_vs_analysis': config.Eval(
           metrics=deterministic_metrics,
           against_analysis=True,
           regions=regions,
           derived_variables=derived_variables,
       ),
-      'probabilistic': config.EvalConfig(
+      'probabilistic': config.Eval(
           metrics={
               'crps': metrics.CRPS(ensemble_dim=ENSEMBLE_DIM.value),
               'ensemble_mean_rmse': metrics.EnsembleMeanRMSE(
@@ -388,7 +388,7 @@ def main(argv: list[str]) -> None:
           probabilistic_climatology_end_year=PROBABILISTIC_CLIMATOLOGY_END_YEAR.value,
           probabilistic_climatology_hour_interval=PROBABILISTIC_CLIMATOLOGY_HOUR_INTERVAL.value,
       ),
-      'ensemble_forecast_vs_era_experimental_metrics': config.EvalConfig(
+      'ensemble_forecast_vs_era_experimental_metrics': config.Eval(
           metrics={
               'crps_spread': metrics.CRPSSpread(
                   ensemble_dim=ENSEMBLE_DIM.value

--- a/weatherbench2/config.py
+++ b/weatherbench2/config.py
@@ -135,7 +135,7 @@ class Eval:
 
 
 @dataclasses.dataclass
-class VizConfig:
+class Viz:
   """Visualization configuration class."""
 
   results: t.Dict[str, str]

--- a/weatherbench2/config.py
+++ b/weatherbench2/config.py
@@ -151,7 +151,7 @@ class Viz:
 
 
 @dataclasses.dataclass
-class PanelConfig:
+class Panel:
   """Config for each panel."""
 
   metric: str

--- a/weatherbench2/config.py
+++ b/weatherbench2/config.py
@@ -68,7 +68,7 @@ class Paths:
 
 
 @dataclasses.dataclass
-class DataConfig:
+class Data:
   """Data configuration class combining Selection and Paths.
 
   Attributes:

--- a/weatherbench2/config.py
+++ b/weatherbench2/config.py
@@ -91,7 +91,7 @@ class DataConfig:
 
 
 @dataclasses.dataclass
-class EvalConfig:
+class Eval:
   """Evaluation configuration class.
 
   Attributes:

--- a/weatherbench2/evaluation.py
+++ b/weatherbench2/evaluation.py
@@ -223,8 +223,8 @@ def _ensure_consistent_time_step_sizes(
 
 
 def _add_base_variables(
-    data_config: config.DataConfig, eval_config: config.Eval
-) -> config.DataConfig:
+    data_config: config.Data, eval_config: config.Eval
+) -> config.Data:
   """Add required base variables for computing derived variables.
 
   Args:
@@ -286,15 +286,15 @@ def _select_analysis_init_time(
 
 
 def open_forecast_and_truth_datasets(
-    data_config: config.DataConfig,
+    data_config: config.Data,
     eval_config: config.Eval,
     use_dask: bool = False,
 ) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset | None]:
   """Open datasets and select desired slices.
 
   Args:
-    data_config: DataConfig instance.
-    eval_config: Eval instance.
+    data_config: config.Data instance.
+    eval_config: config.Eval instance.
     use_dask: Specifies whether to open datasets using dask.
 
   Returns:
@@ -355,7 +355,7 @@ def open_forecast_and_truth_datasets(
 
 
 def _get_output_path(
-    data_config: config.DataConfig, eval_name: str, output_format: str
+    data_config: config.Data, eval_name: str, output_format: str
 ) -> str:
   if output_format == 'netcdf':
     suffix = 'nc'
@@ -422,7 +422,7 @@ def _metric_and_region_loop(
 def _evaluate_all_metrics(
     eval_name: str,
     eval_config: config.Eval,
-    data_config: config.DataConfig,
+    data_config: config.Data,
 ) -> None:
   """Evaluate a set of eval metrics in memory."""
   forecast, truth, climatology = open_forecast_and_truth_datasets(
@@ -464,7 +464,7 @@ def _evaluate_all_metrics(
 
 
 def evaluate_in_memory(
-    data_config: config.DataConfig,
+    data_config: config.Data,
     eval_configs: dict[str, config.Eval],
 ) -> None:
   """Run evaluation in memory.
@@ -487,7 +487,7 @@ def evaluate_in_memory(
   ```
 
   Args:
-    data_config: DataConfig instance.
+    data_config: config.Data instance.
     eval_configs: Dictionary of config.Eval instances.
   """
   for eval_name, eval_config in eval_configs.items():
@@ -499,7 +499,7 @@ class _SaveOutputs(beam.PTransform):
   """Save outputs to Zarr or netCDF."""
 
   eval_name: str
-  data_config: config.DataConfig
+  data_config: config.Data
   output_format: str
 
   def _write_netcdf(self, datasets: list[xr.Dataset]) -> xr.Dataset:
@@ -532,15 +532,15 @@ class _EvaluateAllMetrics(beam.PTransform):
 
   Attributes:
     eval_name: Name of evaluation.
-    eval_config: EvalCongig instance.
-    data_config: DataConfig instance.
+    eval_config: config.Eval instance.
+    data_config: config.Data instance.
     input_chunks: Chunks to use for input files.
     fanout: Fanout parameter for Beam combiners.
   """
 
   eval_name: str
   eval_config: config.Eval
-  data_config: config.DataConfig
+  data_config: config.Data
   input_chunks: abc.Mapping[str, int]
   fanout: Optional[int] = None
 
@@ -696,7 +696,7 @@ class _EvaluateAllMetrics(beam.PTransform):
 
 
 def evaluate_with_beam(
-    data_config: config.DataConfig,
+    data_config: config.Data,
     eval_configs: dict[str, config.Eval],
     *,
     input_chunks: abc.Mapping[str, int],
@@ -724,7 +724,7 @@ def evaluate_with_beam(
   ```
 
   Args:
-    data_config: DataConfig instance.
+    data_config: config.Data instance.
     eval_configs: Dictionary of config.Eval instances.
     input_chunks: Chunking of input datasets.
     runner: Beam runner.

--- a/weatherbench2/evaluation.py
+++ b/weatherbench2/evaluation.py
@@ -223,7 +223,7 @@ def _ensure_consistent_time_step_sizes(
 
 
 def _add_base_variables(
-    data_config: config.DataConfig, eval_config: config.EvalConfig
+    data_config: config.DataConfig, eval_config: config.Eval
 ) -> config.DataConfig:
   """Add required base variables for computing derived variables.
 
@@ -287,14 +287,14 @@ def _select_analysis_init_time(
 
 def open_forecast_and_truth_datasets(
     data_config: config.DataConfig,
-    eval_config: config.EvalConfig,
+    eval_config: config.Eval,
     use_dask: bool = False,
 ) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset | None]:
   """Open datasets and select desired slices.
 
   Args:
     data_config: DataConfig instance.
-    eval_config: EvalConfig instance.
+    eval_config: Eval instance.
     use_dask: Specifies whether to open datasets using dask.
 
   Returns:
@@ -377,7 +377,7 @@ def _to_netcdf(dataset: xr.Dataset, filename: str) -> None:
 def _metric_and_region_loop(
     forecast: xr.Dataset,
     truth: xr.Dataset,
-    eval_config: config.EvalConfig,
+    eval_config: config.Eval,
     compute_chunk: bool = False,
 ) -> xr.Dataset:
   """Compute metric results looping over metrics and regions in eval config."""
@@ -421,7 +421,7 @@ def _metric_and_region_loop(
 
 def _evaluate_all_metrics(
     eval_name: str,
-    eval_config: config.EvalConfig,
+    eval_config: config.Eval,
     data_config: config.DataConfig,
 ) -> None:
   """Evaluate a set of eval metrics in memory."""
@@ -465,11 +465,11 @@ def _evaluate_all_metrics(
 
 def evaluate_in_memory(
     data_config: config.DataConfig,
-    eval_configs: dict[str, config.EvalConfig],
+    eval_configs: dict[str, config.Eval],
 ) -> None:
   """Run evaluation in memory.
 
-  Will save a separate results NetCDF file for each EvalConfig.
+  Will save a separate results NetCDF file for each config.Eval.
   An example for a results dataset with the respective dimensions is given
   below. Note that region and level are optional.
 
@@ -488,7 +488,7 @@ def evaluate_in_memory(
 
   Args:
     data_config: DataConfig instance.
-    eval_configs: Dictionary of EvalConfig instances.
+    eval_configs: Dictionary of config.Eval instances.
   """
   for eval_name, eval_config in eval_configs.items():
     _evaluate_all_metrics(eval_name, eval_config, data_config)
@@ -539,7 +539,7 @@ class _EvaluateAllMetrics(beam.PTransform):
   """
 
   eval_name: str
-  eval_config: config.EvalConfig
+  eval_config: config.Eval
   data_config: config.DataConfig
   input_chunks: abc.Mapping[str, int]
   fanout: Optional[int] = None
@@ -697,7 +697,7 @@ class _EvaluateAllMetrics(beam.PTransform):
 
 def evaluate_with_beam(
     data_config: config.DataConfig,
-    eval_configs: dict[str, config.EvalConfig],
+    eval_configs: dict[str, config.Eval],
     *,
     input_chunks: abc.Mapping[str, int],
     runner: str,
@@ -706,7 +706,7 @@ def evaluate_with_beam(
 ) -> None:
   """Run evaluation with a Beam pipeline.
 
-  Will save a separate results NetCDF file for each EvalConfig.
+  Will save a separate results NetCDF file for each config.Eval.
   An example for a results dataset with the respective dimensions is given
   below. Note that region and level are optional.
 
@@ -725,7 +725,7 @@ def evaluate_with_beam(
 
   Args:
     data_config: DataConfig instance.
-    eval_configs: Dictionary of EvalConfig instances.
+    eval_configs: Dictionary of config.Eval instances.
     input_chunks: Chunking of input datasets.
     runner: Beam runner.
     fanout: Beam CombineFn fanout.

--- a/weatherbench2/evaluation_test.py
+++ b/weatherbench2/evaluation_test.py
@@ -75,7 +75,7 @@ class EvaluationTest(absltest.TestCase):
         output_dir=output_path_1,
     )
 
-    data_config = config.DataConfig(selection=selection, paths=paths)
+    data_config = config.Data(selection=selection, paths=paths)
 
     regions = {
         'global': SliceRegion(),

--- a/weatherbench2/evaluation_test.py
+++ b/weatherbench2/evaluation_test.py
@@ -84,23 +84,23 @@ class EvaluationTest(absltest.TestCase):
     }
 
     eval_configs = {
-        'forecast_vs_era': config.EvalConfig(
+        'forecast_vs_era': config.Eval(
             metrics={
                 'rmse': metrics.RMSE(),
                 'acc': metrics.ACC(climatology=climatology),
             },
             against_analysis=False,
         ),
-        'forecast_vs_era_by_region': config.EvalConfig(
+        'forecast_vs_era_by_region': config.Eval(
             metrics={'rmse': metrics.RMSE()},
             against_analysis=False,
             regions=regions,
         ),
-        'forecast_vs_era_spatial': config.EvalConfig(
+        'forecast_vs_era_spatial': config.Eval(
             metrics={'mse': metrics.SpatialMSE()},
             against_analysis=False,
         ),
-        'forecast_vs_era_temporal': config.EvalConfig(
+        'forecast_vs_era_temporal': config.Eval(
             metrics={'rmse': metrics.RMSE()},
             against_analysis=False,
             temporal_mean=False,

--- a/weatherbench2/visualization.py
+++ b/weatherbench2/visualization.py
@@ -252,7 +252,7 @@ def plot_timeseries(
 
 
 def visualize_timeseries(
-    viz_config: config.VizConfig,
+    viz_config: config.Viz,
     panel_configs: t.Sequence[config.PanelConfig],
     save_path: t.Optional[str] = None,
     subplots_adjust_kwargs: t.Optional[t.Dict[str, float]] = None,
@@ -302,7 +302,7 @@ def visualize_timeseries(
 
 
 def visualize_scorecard(
-    viz_config: config.VizConfig,
+    viz_config: config.Viz,
     baseline: str,
     forecast: str,
     metric: str,

--- a/weatherbench2/visualization.py
+++ b/weatherbench2/visualization.py
@@ -253,7 +253,7 @@ def plot_timeseries(
 
 def visualize_timeseries(
     viz_config: config.Viz,
-    panel_configs: t.Sequence[config.PanelConfig],
+    panel_configs: t.Sequence[config.Panel],
     save_path: t.Optional[str] = None,
     subplots_adjust_kwargs: t.Optional[t.Dict[str, float]] = None,
     legend_position: t.Optional[int] = 2,


### PR DESCRIPTION
For example, it's clear to the user that "config.Eval" refers to a config, rather than "config.EvalConfig". I renamed a few data classes to make all the configs consistent.