### PR TITLE
feat: adding Africa region

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -329,6 +329,10 @@ def main(argv: list[str]) -> None:
           lat_slice=slice(35, 75),
           lon_slice=[slice(360 - 12.5, None), slice(0, 42.5)],
       ),
+      'africa': SliceRegion(
+        lat_slice=slice(-34.8, 37),
+        lon_slice=slice(-17.5, 51.4),
+      ),
       'north-america': SliceRegion(
           lat_slice=slice(25, 60), lon_slice=slice(360 - 120, 360 - 75)
       ),


### PR DESCRIPTION

We have been experimenting with WB2 on the African continent region. We had interesting scores and results available [here](https://github.com/africlimate-research/AfriclimmateAI-Community/blob/main/resources/WeatherBench_2_Skill_Evaluation_Tutorial.ipynb). We think it would be valuable to add Africa in the pre-defined regions and confirm/discuss those results.
On behalf of [AfriClimate](https://www.africlimate.ai/home).

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR