### PR TITLE
Allow later compatible versions of xarray and pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ base_requires = [
     'apache_beam>=2.31.0',
     'jax[cpu]',
     'numpy',
-    'pandas~=2.0.3',
+    'pandas>=2.0.3',
     'scipy',
     'scikit-learn',
     'xarray>=2023.7.0',


### PR DESCRIPTION
Both xarray and pandas currently have fixed versions in the setup.py which means it's fiddly to enable later versions of xarray if we're using weatherbench as a dep. In particular there's a number of improvements in xarray that are worth getting.
By changing the strict equals to the compatible release clause we can use newer versions whilst ensuring things don't break.