### PR TITLE
Fix xarray deprecation warnings

### DIFF
--- a/scripts/compute_climatology.py
+++ b/scripts/compute_climatology.py
@@ -170,7 +170,7 @@ class SEEPSThreshold:
     heavy_threshold = heavy_threshold.quantile(2 / 3, dim=dim)
     out = xr.Dataset(
         {
-            f'{self.var}_seeps_threshold': heavy_threshold.drop('quantile'),
+            f'{self.var}_seeps_threshold': heavy_threshold.drop_vars('quantile'),
             f'{self.var}_seeps_dry_fraction': dry_fraction,
         }
     )  # fmt: skip


### PR DESCRIPTION
# PR Summary
This small PR resolves the `xarray` deprecation warnings:
```python
/home/runner/work/weatherbench2/weatherbench2/scripts/compute_climatology.py:173: DeprecationWarning: dropping variables using `drop` is deprecated; use drop_vars.
```
See more information [here](https://docs.xarray.dev/en/stable/whats-new.html#id258).