### PR TITLE
Clip `output_chunks` to `template.sizes` in `compute_probabilistic_climatological_forecasts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/source/.ipynb_checkpoints
 docs/*.zarr
 __pycache__
 .pytest_cache
+*swp

--- a/scripts/compute_probabilistic_climatological_forecasts.py
+++ b/scripts/compute_probabilistic_climatological_forecasts.py
@@ -940,7 +940,8 @@ def main(argv: abc.Sequence[str]) -> None:
   )  # fmt: skip
   output_chunks.update(OUTPUT_CHUNKS.value)
   output_chunks = {
-          k: min(output_chunks[k], template.sizes[k]) for k in output_chunks}
+      k: min(output_chunks[k], template.sizes[k]) for k in output_chunks
+  }
 
   itemsize = max(var.dtype.itemsize for var in template.values())
 

--- a/scripts/compute_probabilistic_climatological_forecasts.py
+++ b/scripts/compute_probabilistic_climatological_forecasts.py
@@ -939,6 +939,8 @@ def main(argv: abc.Sequence[str]) -> None:
       }
   )  # fmt: skip
   output_chunks.update(OUTPUT_CHUNKS.value)
+  output_chunks = {
+          k: min(output_chunks[k], template.sizes[k]) for k in output_chunks}
 
   itemsize = max(var.dtype.itemsize for var in template.values())
 


### PR DESCRIPTION
This same pattern is used elsewhere. See e.g. `compute_quantiles.py` line 215.

- [X] Tests pass
- [NA ] Appropriate changes to documentation are included in the PR
- CLA is signed (yesterday, by Gridmatic)