### PR TITLE
Weatherbench2 Updates: DataFlow usage, new LongitudeScheme, and .gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/*.zarr
 __pycache__
 .pytest_cache
 *swp
+.venv*
+.direnv
+.envrc

--- a/scripts/regrid.py
+++ b/scripts/regrid.py
@@ -54,6 +54,7 @@ OUTPUT_PATH = flags.DEFINE_string('output_path', None, help='zarr outputs')
 OUTPUT_CHUNKS = flag_utils.DEFINE_chunks(
     'output_chunks', '', help='desired chunking of output zarr'
 )
+flags.declare_key_flag('output_chunks')
 LATITUDE_NODES = flags.DEFINE_integer(
     'latitude_nodes', None, help='number of desired latitude nodes'
 )
@@ -73,6 +74,8 @@ LONGITUDE_SCHEME = flags.DEFINE_enum_class(
     help=(
         'What values the output longitude dimension will have. With Δ = 360 /'
         ' LONGITUDE_NODES, "START_AT_ZERO" means longitude=[0, ..., 360 - Δ].'
+        ' "START_AT_NEGATIVE_ONE_EIGHTY" means '
+        'longitude=[-180, -180 + Δ, ..., 180 - Δ].'
         ' "CENTER_AT_ZERO" means longitude=[-180 + Δ/2, ..., 180 - Δ/2]'
     ),
 )
@@ -87,6 +90,11 @@ LATITUDE_NAME = flags.DEFINE_string(
 )
 LONGITUDE_NAME = flags.DEFINE_string(
     'longitude_name', 'longitude', help='Name of longitude dimension in dataset'
+)
+MAX_MEM = flags.DEFINE_integer(
+    'max_mem',
+    2**30,
+    help='Maximum memory (in bytes) during rechunking.',
 )
 NUM_THREADS = flags.DEFINE_integer(
     'num_threads',
@@ -161,6 +169,7 @@ def main(argv):
             input_chunks,
             output_chunks,
             itemsize=itemsize,
+            max_mem=MAX_MEM.value,
         )
         | xarray_beam.ChunksToZarr(
             OUTPUT_PATH.value,

--- a/scripts/regrid_test.py
+++ b/scripts/regrid_test.py
@@ -33,7 +33,7 @@ class RegridTest(parameterized.TestCase):
       dict(
           input_longitude_scheme=LongitudeScheme.CENTER_AT_ZERO,
           input_latitude_spacing=LatitudeSpacing.EQUIANGULAR_WITHOUT_POLES,
-          output_longitude_scheme=LongitudeScheme.START_AT_ZERO,
+          output_longitude_scheme=LongitudeScheme.START_AT_NEGATIVE_ONE_EIGHTY,
           output_latitude_spacing=LatitudeSpacing.EQUIANGULAR_WITH_POLES,
       ),
       dict(

--- a/scripts/slice_dataset.py
+++ b/scripts/slice_dataset.py
@@ -22,7 +22,7 @@ Example Usage:
   export PROJECT=my-project
   export REGION=us-central1
 
-  python scripts/resample_in_time.py \
+  python scripts/slice_dataset.py \
     --input_path=gs://weatherbench2/datasets/era5/1959-2022-6h-64x32_equiangular_with_poles_conservative.zarr \
     --output_path=gs://$BUCKET/datasets/era5/$USER/2020-2021-weekly-average-temperature.zarr \
     --runner=DataflowRunner \
@@ -69,6 +69,7 @@ SEL = flag_utils.DEFINE_dim_value_pairs(
         'but falls back to string. '
     ),
 )
+flags.declare_key_flag("sel")  # To make it appear with --help or --helpshort
 
 SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
     'sel_strings',
@@ -83,6 +84,7 @@ SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
         'Useful, since years should be sliced using strings like "2000". '
     ),
 )
+flags.declare_key_flag("sel_strings")
 
 ISEL = flag_utils.DEFINE_dim_value_pairs(
     'isel',
@@ -95,6 +97,7 @@ ISEL = flag_utils.DEFINE_dim_value_pairs(
         'a list of "+" delimited ints.'
     ),
 )
+flags.declare_key_flag("isel")
 
 DROP_SEL = flag_utils.DEFINE_dim_value_pairs(
     'drop_sel',
@@ -109,6 +112,7 @@ DROP_SEL = flag_utils.DEFINE_dim_value_pairs(
         'but falls back to string. '
     ),
 )
+flags.declare_key_flag("drop_sel")
 
 DROP_SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
     'drop_sel_strings',
@@ -123,6 +127,7 @@ DROP_SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
         'Useful, since years should be sliced using strings like "2000". '
     ),
 )
+flags.declare_key_flag("drop_sel_strings")
 
 DROP_ISEL = flag_utils.DEFINE_dim_value_pairs(
     'drop_isel',
@@ -135,6 +140,7 @@ DROP_ISEL = flag_utils.DEFINE_dim_value_pairs(
         'a list of "+" delimited ints.'
     ),
 )
+flags.declare_key_flag("drop_isel")
 
 DROP_VARIABLES = flags.DEFINE_list(
     'drop_variables',
@@ -157,6 +163,7 @@ KEEP_VARIABLES = flags.DEFINE_list(
 OUTPUT_CHUNKS = flag_utils.DEFINE_chunks(
     'output_chunks', '', help='Chunk sizes overriding input chunks.'
 )
+flags.declare_key_flag("output_chunks")
 
 RUNNER = flags.DEFINE_string(
     'runner', None, help='Beam runner. Use DirectRunner for local execution.'
@@ -166,6 +173,11 @@ MAKE_DIMS_INCREASING = flags.DEFINE_list(
     [],
     help='Dimensions to make increasing, reversing order if needed.',
 )
+MAX_MEM = flags.DEFINE_integer(
+    'max_mem',
+    2**30,
+    help='Maximum memory (in bytes) during rechunking.',
+)
 NUM_THREADS = flags.DEFINE_integer(
     'num_threads',
     None,
@@ -173,6 +185,13 @@ NUM_THREADS = flags.DEFINE_integer(
 )
 
 # pylint: disable=logging-fstring-interpolation
+
+
+def _assert_nonzero_sizes(sizes: dict[str, int]) -> None:
+  """Asserts every value (which should be a size) is nonzero."""
+  for k, v in sizes.items():
+    if v == 0:
+      raise ValueError(f'Size for {k} is not allowed: {v}')
 
 
 def _maybe_make_some_dims_increasing(ds: xr.Dataset) -> xr.Dataset:
@@ -280,6 +299,9 @@ def main(argv: abc.Sequence[str]) -> None:
     else:
       output_chunks[k] = min(output_chunks[k], ds.sizes[k])
 
+  _assert_nonzero_sizes(ds.sizes)
+  _assert_nonzero_sizes(output_chunks)
+
   itemsize = max(var.dtype.itemsize for var in template.values())
 
   with beam.Pipeline(runner=RUNNER.value, argv=argv) as root:
@@ -294,6 +316,7 @@ def main(argv: abc.Sequence[str]) -> None:
             input_chunks,
             output_chunks,
             itemsize=itemsize,
+            max_mem=MAX_MEM.value,
         )
         | xbeam.ChunksToZarr(
             OUTPUT_PATH.value,

--- a/scripts/slice_dataset.py
+++ b/scripts/slice_dataset.py
@@ -69,7 +69,7 @@ SEL = flag_utils.DEFINE_dim_value_pairs(
         'but falls back to string. '
     ),
 )
-flags.declare_key_flag("sel")  # To make it appear with --help or --helpshort
+flags.declare_key_flag('sel')  # To make it appear with --help or --helpshort
 
 SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
     'sel_strings',
@@ -84,7 +84,7 @@ SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
         'Useful, since years should be sliced using strings like "2000". '
     ),
 )
-flags.declare_key_flag("sel_strings")
+flags.declare_key_flag('sel_strings')
 
 ISEL = flag_utils.DEFINE_dim_value_pairs(
     'isel',
@@ -97,7 +97,7 @@ ISEL = flag_utils.DEFINE_dim_value_pairs(
         'a list of "+" delimited ints.'
     ),
 )
-flags.declare_key_flag("isel")
+flags.declare_key_flag('isel')
 
 DROP_SEL = flag_utils.DEFINE_dim_value_pairs(
     'drop_sel',
@@ -112,7 +112,7 @@ DROP_SEL = flag_utils.DEFINE_dim_value_pairs(
         'but falls back to string. '
     ),
 )
-flags.declare_key_flag("drop_sel")
+flags.declare_key_flag('drop_sel')
 
 DROP_SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
     'drop_sel_strings',
@@ -127,7 +127,7 @@ DROP_SEL_STRINGS = flag_utils.DEFINE_dim_value_pairs(
         'Useful, since years should be sliced using strings like "2000". '
     ),
 )
-flags.declare_key_flag("drop_sel_strings")
+flags.declare_key_flag('drop_sel_strings')
 
 DROP_ISEL = flag_utils.DEFINE_dim_value_pairs(
     'drop_isel',
@@ -140,7 +140,7 @@ DROP_ISEL = flag_utils.DEFINE_dim_value_pairs(
         'a list of "+" delimited ints.'
     ),
 )
-flags.declare_key_flag("drop_isel")
+flags.declare_key_flag('drop_isel')
 
 DROP_VARIABLES = flags.DEFINE_list(
     'drop_variables',
@@ -163,7 +163,7 @@ KEEP_VARIABLES = flags.DEFINE_list(
 OUTPUT_CHUNKS = flag_utils.DEFINE_chunks(
     'output_chunks', '', help='Chunk sizes overriding input chunks.'
 )
-flags.declare_key_flag("output_chunks")
+flags.declare_key_flag('output_chunks')
 
 RUNNER = flags.DEFINE_string(
     'runner', None, help='Beam runner. Use DirectRunner for local execution.'

--- a/weatherbench2/regridding.py
+++ b/weatherbench2/regridding.py
@@ -48,6 +48,9 @@ class LongitudeScheme(enum.Enum):
   # [-180 + Δ/2, ..., 180 - Δ/2]
   CENTER_AT_ZERO = enum.auto()
 
+  # [-180, -180 + Δ, ..., 180 - Δ]
+  START_AT_NEGATIVE_ONE_EIGHTY = enum.auto()
+
 
 class LatitudeSpacing(enum.Enum):
   EQUIANGULAR_WITH_POLES = enum.auto()
@@ -73,6 +76,9 @@ def longitude_values(longitude_scheme: LongitudeScheme, num: int) -> np.ndarray:
   if longitude_scheme == LongitudeScheme.START_AT_ZERO:
     lon_start = 0
     lon_stop = 360 - lon_delta
+  elif longitude_scheme == LongitudeScheme.START_AT_NEGATIVE_ONE_EIGHTY:
+    lon_start = -180
+    lon_stop = 180 - lon_delta
   elif longitude_scheme == LongitudeScheme.CENTER_AT_ZERO:
     lon_start = -180 + lon_delta / 2
     lon_stop = 180 - lon_delta / 2
@@ -175,6 +181,8 @@ def _determine_longitude_scheme(
   eq = lambda a, b: np.allclose(a, b, atol=1e-5)
   if eq(lon_in_degrees[0], 0) and lon_in_degrees[-1] < 360:
     return LongitudeScheme.START_AT_ZERO
+  elif eq(lon_in_degrees[0], -180) and lon_in_degrees[-1] < 180:
+    return LongitudeScheme.START_AT_NEGATIVE_ONE_EIGHTY
   elif lon_in_degrees[0] < 0 and eq(-lon_in_degrees[0], lon_in_degrees[-1]):
     return LongitudeScheme.CENTER_AT_ZERO
   else:


### PR DESCRIPTION
Public changes to `Weatherbench2`

* Changes to `scripts/` to allow running on `DataFlow` : Pass flag values to `DoFn`s, rather than rely FLAGs being readable.
* Add `START_AT_NEGATIVE_ONE_EIGHTY` as a `LongitudeScheme` in `regrid.py`
* Add some environment files to `.gitignore`
* Add `TIMEDELTA_NAME` FLAG to `compute_probabilistic_climatological_forecasts.py`
* Starting using `flags.declare_key_flag` pattern to make our custom flags show up in `--help`
* Add `MAX_MEM` FLAG to a couple scripts